### PR TITLE
Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,6 @@ node_js:
   - "5"
   - "4"
 
-env:
-  - CXX="g++-4.8"
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-      - gcc-4.8
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install libzmq3-dev
-
 after_script:
   - npm run coveralls
 

--- a/examples/cli-extended.js
+++ b/examples/cli-extended.js
@@ -1,11 +1,7 @@
 'use strict'
 
 function sayHello (rinvoke, opts, next) {
-  rinvoke
-    .serializer(JSON.stringify)
-    .parser(JSON.parse)
-
-  rinvoke.register('hello', reply => {
+  rinvoke.register('hello', (req, reply) => {
     reply(null, { hello: 'world' })
   })
 

--- a/examples/cli-single-function.js
+++ b/examples/cli-single-function.js
@@ -1,8 +1,8 @@
 'use strict'
 
-function sayHello (reply) {
+function sayHello (req, reply) {
   reply(null, 'hello!')
 }
 
 module.exports = sayHello
-module.exports.key = 'hello'
+module.exports.procedure = 'hello'

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,8 +1,24 @@
 'use strict'
 
-const rinvoke = require('../index')()
+const rinvoke = require('../client')({
+  port: 3030,
+  host: '127.0.0.1'
+})
 
-rinvoke.invoke('cmd:concat', 'a', 'b', (err, result) => {
+rinvoke.invoke({
+  procedure: 'concat',
+  a: 'a',
+  b: 'b'
+}, (err, result) => {
   if (err) console.log(err)
   console.log(result)
 })
+
+rinvoke
+  .invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  })
+  .then(console.log)
+  .catch(console.log)

--- a/examples/custom-serializer.js
+++ b/examples/custom-serializer.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const msgpack = require('msgpack5')()
+const server = require('../lib/server')({
+  codec: msgpack
+})
+const Client = require('../lib/client')
+
+// register a new function
+server.register('concat', (req, reply) => reply(null, req.a + req.b))
+
+// run the listener
+server.listen(3030, err => {
+  if (err) throw err
+
+  // connect to the listener
+  const client = Client({
+    port: 3030,
+    codec: msgpack
+  })
+  // invoke the remote function
+  client.invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  }, (err, res) => {
+    if (err) console.log(err)
+    console.log('concat:', res)
+    // close the connections
+    server.close(err => { if (err) throw err })
+    client.close(err => { if (err) throw err })
+  })
+})

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,23 +1,27 @@
 'use strict'
 
 const server = require('../lib/server')()
-const client = require('../lib/client')()
+const Client = require('../lib/client')
 
 // register a new function
-server.register('cmd:concat', (a, b, reply) => reply(null, a + b))
+server.register('concat', (req, reply) => reply(null, req.a + req.b))
 
 // run the listener
-server.run('tcp://127.0.0.1:3030', err => {
+server.listen(3030, err => {
   if (err) throw err
 
   // connect to the listener
-  client.connect('tcp://127.0.0.1:3030')
+  const client = Client({ port: 3030 })
   // invoke the remote function
-  client.invoke('cmd:concat', 'a', 'b', (err, res) => {
+  client.invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  }, (err, res) => {
     if (err) console.log(err)
     console.log('concat:', res)
     // close the connections
     server.close(err => { if (err) throw err })
-    client.close()
+    client.close(err => { if (err) throw err })
   })
 })

--- a/examples/reconnect.js
+++ b/examples/reconnect.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const server = require('../lib/server')()
+const Client = require('../lib/client')
+
+// register a new function
+server.register('concat', (req, reply) => reply(null, req.a + req.b))
+
+// run the listener
+server.listen(3030, err => {
+  if (err) throw err
+
+  // connect to the listener
+  const client = Client({
+    port: 3030,
+    reconnect: { // could be also true
+      attempts: 3,
+      timeout: 1000
+    }
+  })
+  // invoke the remote function
+  client.invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  }, (err, res) => {
+    if (err) console.log(err)
+    console.log('concat:', res)
+    // close the connections
+    server.close(err => { if (err) throw err })
+    client.close(err => { if (err) throw err })
+  })
+})

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,5 +1,9 @@
 'use strict'
 
-const rinvoke = require('../index')()
+const rinvoke = require('../server')()
 
-rinvoke.register('cmd:concat', (a, b, reply) => reply(null, a + b))
+rinvoke.register('concat', (req, reply) => reply(null, req.a + req.b))
+
+rinvoke.listen(3030, err => {
+  if (err) throw err
+})

--- a/examples/use.js
+++ b/examples/use.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const server = require('../lib/server')()
+const Client = require('../lib/client')
+
+server.use((instance, opts, next) => {
+  instance.concat = (a, b) => a + b
+  next()
+})
+// register a new function
+server.register('concat', (req, reply) => {
+  reply(null, server.concat(req.a, req.b))
+})
+
+// run the listener
+server.listen(3030, err => {
+  if (err) throw err
+
+  // connect to the listener
+  const client = Client({ port: 3030 })
+  // invoke the remote function
+  client.invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  }, (err, res) => {
+    if (err) console.log(err)
+    console.log('concat:', res)
+    // close the connections
+    server.close(err => { if (err) throw err })
+    client.close(err => { if (err) throw err })
+  })
+})

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -7,6 +7,7 @@ const minimist = require('minimist')
 const Server = require('./server')
 
 function start (opts, callback) {
+  /* istanbul ignore if */
   if (opts.help) {
     return
   }
@@ -15,23 +16,27 @@ function start (opts, callback) {
   try {
     fn = require(path.resolve(process.cwd(), opts._[0]))
   } catch (e) {
+    /* istanbul ignore next */
     console.log(`Cannot find the specified file: '${opts._[0]}'`)
+    /* istanbul ignore next */
     process.exit(1)
   }
 
-  const server = Server()
-  if (fn.key) {
-    server.register(fn.key, fn)
+  const server = Server(opts)
+  if (fn.procedure) {
+    server.register(fn.procedure, fn)
   } else {
     server.use(fn)
   }
 
-  server.run(`${opts.protocol}://${opts.address}:${opts.port}`, err => {
+  server.listen(opts.port, err => {
+    /* istanbul ignore if */
     if (err) throw err
+    /* istanbul ignore else */
     if (callback) {
       callback(server)
     } else {
-      console.log(`Function listening at ${opts.protocol}://${opts.address}:${opts.port}`)
+      console.log(`Function listening at ${opts.port}`)
     }
   })
 }
@@ -43,13 +48,11 @@ function cli () {
     alias: {
       port: 'p',
       help: 'h',
-      address: 'a',
-      protocol: 'P'
+      address: 'a'
     },
     default: {
       port: 3000,
-      address: '127.0.0.1',
-      protocol: 'tcp'
+      host: '127.0.0.1'
     }
   }))
 }

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -48,7 +48,8 @@ function cli () {
     alias: {
       port: 'p',
       help: 'h',
-      address: 'a'
+      address: 'a',
+      path: 'P'
     },
     default: {
       port: 3000,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,95 +1,67 @@
 'use strict'
 
 const assert = require('assert')
-const zmq = require('zmq')
-const Hyperid = require('hyperid')
+const EE = require('events').EventEmitter
+const inherits = require('util').inherits
+const net = require('net')
+const pump = require('pump')
+const tentacoli = require('tentacoli')
+const avvio = require('avvio')
+const promisify = require('util.promisify')
 
-function Client () {
+function Client (opts) {
   if (!(this instanceof Client)) {
-    return new Client()
+    return new Client(opts)
   }
 
-  this._socket = zmq.socket('req')
+  avvio(this)
 
-  this._callbacks = Object.create(null)
-  this._hyperid = Hyperid()
-
-  this._serializer = payload => payload
-  this._parser = payload => payload.toString()
-  this._errorParser = payload => {
-    try {
-      return JSON.parse(payload)
-    } catch (err) {
-      return payload.toString ? payload.toString() : payload
-    }
+  this._opts = opts || {}
+  this._opts.host = this._opts.host || '127.0.0.1'
+  this._opts.codec = this._opts.codec || {
+    encode: JSON.stringify,
+    decode: JSON.parse
   }
 
-  this._socket.on('message', this._onMessage.bind(this))
+  this._socket = null
+  this._client = null
+
+  this.ready(runClient)
+  this.isReady = false
+
+  this.onClose(instance => {
+    instance._socket.unref()
+    instance._client.destroy()
+  })
 }
 
-Client.prototype.invoke = function () {
-  const args = new Array(arguments.length - 1)
-  const cb = arguments[arguments.length - 1]
-  const cmd = arguments[0]
+function runClient (err, context, done) {
+  /* istanbul ignore if */
+  if (err) throw err
+  context._socket = net.connect(context._opts.port, context._opts.host)
+  context._client = tentacoli(context._opts)
+  pump(context._socket, context._client, context._socket)
 
-  for (var i = 1; i < args.length; i++) {
-    args[i] = this._serializer(arguments[i])
+  context._socket.on('connect', () => {
+    context.isReady = true
+    context.emit('connect')
+    done()
+  })
+}
+
+inherits(Client, EE)
+
+Client.prototype.invoke = promisify(function invoke (opts, cb) {
+  assert(typeof opts.procedure === 'string', 'Procedure must be a string')
+
+  if (!this.isReady) {
+    this.once('connect', () => {
+      this._client.request(opts, cb)
+    })
+    return
   }
 
-  const id = this._hyperid()
-  this._callbacks[id] = cb
-  args[0] = cmd
-  args.push(id)
-
-  this._socket.send(args)
-}
-
-Client.prototype.connect = function (address) {
-  assert(typeof address === 'string', 'address should be a string')
-  this._socket.connect(address)
-}
-
-Client.prototype.parser = function (parser) {
-  assert(typeof parser === 'function', 'parser must be a function')
-  this._parser = parser
-  return this
-}
-
-Client.prototype.errorParser = function (parser) {
-  assert(typeof parser === 'function', 'parser must be a function')
-  this._errorParser = parser
-  return this
-}
-
-Client.prototype.serializer = function (serializer) {
-  assert(typeof serializer === 'function', 'serializer must be a function')
-  this._serializer = serializer
-  return this
-}
-
-Client.prototype._onMessage = function () {
-  const args = new Array(arguments.length - 1)
-
-  for (var i = 1; i < args.length; i++) {
-    args[i] = this._parser(arguments[i])
-  }
-  args[0] = this._errorParser(arguments[0])
-
-  const id = arguments[arguments.length - 1].toString()
-  const fn = this._callbacks[id]
-  if (!fn) return
-  delete this._callbacks[id]
-
-  fn.apply(null, args)
-}
-
-Client.prototype.close = function () {
-  this._socket.close()
-}
-
-Client.prototype.disconnect = function (address) {
-  assert(typeof address === 'string', 'address should be a string')
-  this._socket.disconnect(address)
-}
+  this._client.request(opts, cb)
+})
 
 module.exports = Client

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const debug = require('debug')('rinvoke-client')
 const assert = require('assert')
 const EE = require('events').EventEmitter
 const inherits = require('util').inherits
@@ -23,14 +24,25 @@ function Client (opts) {
     decode: JSON.parse
   }
 
+  this._reconnect = !!this._opts.reconnect
+  if (typeof this._opts.reconnect !== 'object') {
+    this._opts.reconnect = {}
+  }
+  this._reconnectAttempts = this._opts.reconnect.attempts || 3
+  this._reconnectTimeout = this._opts.reconnect.timeout || 1000
+  this._reconnectAttemptsCount = 0
+
   this._socket = null
   this._client = null
 
   this.ready(runClient)
   this.isReady = false
+  this.isClosing = false
 
   this.onClose(instance => {
-    instance._socket.unref()
+    debug('on close')
+    instance.isClosing = true
+    instance._socket.end()
     instance._client.destroy()
   })
 }
@@ -39,33 +51,90 @@ function runClient (err, context, done) {
   /* istanbul ignore if */
   if (err) throw err
   if (context._opts.path) {
+    debug('run the ipc client')
     context._socket = net.connect(context._opts.path)
   } else {
+    debug('run the tcp client')
     context._socket = net.connect(context._opts.port, context._opts.host)
   }
   context._client = tentacoli(context._opts)
   pump(context._socket, context._client, context._socket)
 
-  context._socket.on('connect', () => {
+  context._socket.on('connect', handleConnect)
+  function handleConnect () {
+    debug('connected to the server')
     context.isReady = true
+    context._reconnectAttemptsCount = 0
     context.emit('connect')
     done()
-  })
+  }
 
-  context._socket.on('timeout', () => {
-    context.close()
-    context.emit('timeout')
-  })
+  context._socket.on('timeout', handleTimeout)
+  /* istanbul ignore next */
+  function handleTimeout () {
+    debug('socket timeout event')
+    handleReconnect(() => {
+      context.close()
+      context.emit('timeout')
+    })
+  }
 
-  context._socket.on('error', err => {
-    context.close()
-    context.emit('error', err)
-  })
+  context._socket.on('error', handleError)
+  /* istanbul ignore next */
+  function handleError (err) {
+    debug('socket error event', err)
+    handleReconnect(() => {
+      context.close()
+      context.emit('error', err)
+    })
+  }
 
-  context._client.on('error', err => {
-    context.close()
-    context.emit('error', err)
-  })
+  context._socket.on('close', handleClose)
+  /* istanbul ignore next */
+  function handleClose () {
+    debug('socket close event')
+    if (context.isClosing) return
+    handleReconnect(() => {
+      context.close()
+      context.emit('close')
+    })
+  }
+
+  context._client.on('error', handleTError)
+  /* istanbul ignore next */
+  function handleTError (err) {
+    debug('tentacoli error event', err)
+    handleReconnect(() => {
+      context.close()
+      context.emit('error', err)
+    })
+  }
+
+  function handleReconnect (cb) {
+    if (!context._reconnect) {
+      cb()
+    } else if (context._reconnectAttemptsCount++ >= context._reconnectAttempts) {
+      cb()
+    } else {
+      debug('remove listeners before try reconnect')
+      context._socket.removeListener('connect', handleConnect)
+      context._socket.removeListener('timeout', handleTimeout)
+      context._socket.removeListener('error', handleError)
+      context._socket.removeListener('close', handleClose)
+      context._client.removeListener('error', handleTError)
+
+      context._socket.destroy()
+      context._client.destroy()
+      context._socket = null
+      context._client = null
+      context.isReady = false
+
+      setTimeout(() => {
+        debug('try reconnect')
+        runClient(null, context, () => {})
+      }, context._reconnectTimeout)
+    }
+  }
 }
 
 inherits(Client, EE)
@@ -74,17 +143,21 @@ Client.prototype.invoke = promisify(function invoke (opts, cb) {
   assert(typeof opts.procedure === 'string', 'Procedure must be a string')
 
   if (!this.isReady) {
+    debug('client not ready yet, wait for connect')
     this.once('connect', () => {
+      debug('invoke', opts)
       this._client.request(opts, cb)
     })
     return
   }
 
+  debug('invoke', opts)
   this._client.request(opts, cb)
 })
 
 Client.prototype.timeout = function timeout (t) {
   assert(typeof t === 'number', 'timeout must be a number')
+  debug('set timeout', t)
 
   if (!this.isReady) {
     this.once('connect', () => {
@@ -94,6 +167,20 @@ Client.prototype.timeout = function timeout (t) {
   }
 
   this._socket.setTimeout(t)
+}
+
+Client.prototype.keepAlive = function timeout (bool) {
+  assert(typeof bool === 'boolean', 'keepAlive must be a boolean')
+  debug('set keep alive', bool)
+
+  if (!this.isReady) {
+    this.once('connect', () => {
+      this._socket.setKeepAlive(bool)
+    })
+    return
+  }
+
+  this._socket.setKeepAlive(bool)
 }
 
 module.exports = Client

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,7 +38,11 @@ function Client (opts) {
 function runClient (err, context, done) {
   /* istanbul ignore if */
   if (err) throw err
-  context._socket = net.connect(context._opts.port, context._opts.host)
+  if (context._opts.path) {
+    context._socket = net.connect(context._opts.path)
+  } else {
+    context._socket = net.connect(context._opts.port, context._opts.host)
+  }
   context._client = tentacoli(context._opts)
   pump(context._socket, context._client, context._socket)
 
@@ -46,6 +50,21 @@ function runClient (err, context, done) {
     context.isReady = true
     context.emit('connect')
     done()
+  })
+
+  context._socket.on('timeout', () => {
+    context.close()
+    context.emit('timeout')
+  })
+
+  context._socket.on('error', err => {
+    context.close()
+    context.emit('error', err)
+  })
+
+  context._client.on('error', err => {
+    context.close()
+    context.emit('error', err)
   })
 }
 
@@ -63,5 +82,18 @@ Client.prototype.invoke = promisify(function invoke (opts, cb) {
 
   this._client.request(opts, cb)
 })
+
+Client.prototype.timeout = function timeout (t) {
+  assert(typeof t === 'number', 'timeout must be a number')
+
+  if (!this.isReady) {
+    this.once('connect', () => {
+      this._socket.setTimeout(t)
+    })
+    return
+  }
+
+  this._socket.setTimeout(t)
+}
 
 module.exports = Client

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,9 @@ const net = require('net')
 const pump = require('pump')
 const tentacoli = require('tentacoli')
 const avvio = require('avvio')
+const EE = require('events').EventEmitter
+const inherits = require('util').inherits
+
 /* istanbul ignore next */
 const noop = err => { if (err) throw err }
 
@@ -18,6 +21,15 @@ function Server (opts) {
   this._functions = Object.create(null)
   this._server = net.createServer(create.bind(this))
 
+  this._server.on('error', err => {
+    this.close()
+    this.emit('error', err)
+  })
+
+  this._server.on('connection', () => {
+    this.emit('connection')
+  })
+
   this._opts = opts || {}
   this._opts.codec = this._opts.codec || {
     encode: JSON.stringify,
@@ -29,10 +41,17 @@ function Server (opts) {
   })
 }
 
+inherits(Server, EE)
+
 function create (original) {
   const stream = tentacoli(this._opts)
   pump(stream, original, stream)
   stream.on('request', handle.bind(this))
+
+  stream.on('error', err => {
+    this.close()
+    this.emit('error', err)
+  })
 }
 
 function handle (request, reply) {
@@ -63,13 +82,13 @@ Server.prototype.register = function (procedure, fn) {
   return this
 }
 
-Server.prototype.listen = function (port, cb) {
-  assert(typeof port === 'number', 'port should be a number')
+Server.prototype.listen = function (portOrPath, cb) {
+  assert(typeof portOrPath === 'number' || typeof portOrPath === 'string', 'portOrPath should be a number or a string')
   cb = cb || noop
   this.ready(err => {
     /* istanbul ignore if */
     if (err) return cb(err)
-    this._server.listen(port, cb)
+    this._server.listen(portOrPath, cb)
   })
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,90 +1,49 @@
 'use strict'
 
 const assert = require('assert')
-const EE = require('events').EventEmitter
-const inherits = require('util').inherits
-const zmq = require('zmq')
-const Bloomrun = require('bloomrun')
-const tinysonic = require('tinysonic')
+const net = require('net')
+const pump = require('pump')
+const tentacoli = require('tentacoli')
 const avvio = require('avvio')
+/* istanbul ignore next */
 const noop = err => { if (err) throw err }
 
-function Server () {
+function Server (opts) {
   if (!(this instanceof Server)) {
-    return new Server()
+    return new Server(opts)
   }
 
   avvio(this)
 
-  this._bloomrun = Bloomrun()
-  this._socket = zmq.socket('rep')
+  this._functions = Object.create(null)
+  this._server = net.createServer(create.bind(this))
 
-  this._serializer = payload => payload
-  this._errorSerializer = err => JSON.stringify(err)
-  this._parser = payload => payload.toString()
-
-  this._socket.on('message', this._onMessage.bind(this))
-
-  this.onClose(instance => {
-    instance.emit('close', instance)
-    instance._socket.close()
-  })
-}
-
-inherits(Server, EE)
-
-Server.prototype.register = function (key, fn) {
-  assert(typeof key === 'string', 'key must be a string')
-  assert(typeof fn === 'function', 'fn must be a function')
-  this._bloomrun.add(tinysonic(key) || key, fn)
-  return this
-}
-
-Server.prototype.run = function (address, cb) {
-  assert(typeof address === 'string', 'address should be a string')
-  cb = cb || noop
-  this.ready(() => {
-    try {
-      this._socket.bindSync(address)
-      cb(null)
-    } catch (err) {
-      cb(err)
-    }
-  })
-}
-
-Server.prototype.parser = function (parser) {
-  assert(typeof parser === 'function', 'parser must be a function')
-  this._parser = parser
-  return this
-}
-
-Server.prototype.serializer = function (serializer) {
-  assert(typeof serializer === 'function', 'serializer must be a function')
-  this._serializer = serializer
-  return this
-}
-
-Server.prototype.errorSerializer = function (serializer) {
-  assert(typeof serializer === 'function', 'serializer must be a function')
-  this._errorSerializer = serializer
-  return this
-}
-
-Server.prototype._onMessage = function () {
-  const args = new Array(arguments.length - 1)
-  const pattern = arguments[0].toString()
-
-  for (var i = 1; i < args.length; i++) {
-    args[i] = this._parser(arguments[i])
+  this._opts = opts || {}
+  this._opts.codec = this._opts.codec || {
+    encode: JSON.stringify,
+    decode: JSON.parse
   }
-  args.shift()
-  args.push(reply.bind(this))
 
-  const id = arguments[arguments.length - 1].toString()
-  const fn = this._bloomrun.lookup(tinysonic(pattern) || pattern)
+  this.onClose((instance, done) => {
+    instance._server.close(done)
+  })
+}
 
-  const result = fn.apply(this, args)
+function create (original) {
+  const stream = tentacoli(this._opts)
+  pump(stream, original, stream)
+  stream.on('request', handle.bind(this))
+}
+
+function handle (request, reply) {
+  var fn = this._functions[request.procedure]
+  if (fn) {
+    var result = fn.call(this, request, reply)
+  } else {
+    reply(new Error('404'), null)
+    return
+  }
+
   if (result && result.then) {
     result
       .then(res => {
@@ -94,14 +53,24 @@ Server.prototype._onMessage = function () {
         reply.call(this, err, null)
       })
   }
+}
 
-  function reply (err, payload, opts) {
-    this._socket.send([
-      this._errorSerializer(err),
-      this._serializer(payload, opts),
-      id
-    ])
-  }
+Server.prototype.register = function (procedure, fn) {
+  assert(typeof procedure === 'string', 'key must be a string')
+  assert(typeof fn === 'function', 'fn must be a function')
+  assert(!this._functions[procedure], `You have already registered procedure '${procedure}'`)
+  this._functions[procedure] = fn
+  return this
+}
+
+Server.prototype.listen = function (port, cb) {
+  assert(typeof port === 'number', 'port should be a number')
+  cb = cb || noop
+  this.ready(err => {
+    /* istanbul ignore if */
+    if (err) return cb(err)
+    this._server.listen(port, cb)
+  })
 }
 
 module.exports = Server

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const debug = require('debug')('rinvoke-server')
 const assert = require('assert')
 const net = require('net')
 const pump = require('pump')
@@ -21,12 +22,15 @@ function Server (opts) {
   this._functions = Object.create(null)
   this._server = net.createServer(create.bind(this))
 
+  /* istanbul ignore next */
   this._server.on('error', err => {
+    debug('error event', err)
     this.close()
     this.emit('error', err)
   })
 
   this._server.on('connection', () => {
+    debug('new connection')
     this.emit('connection')
   })
 
@@ -37,6 +41,7 @@ function Server (opts) {
   }
 
   this.onClose((instance, done) => {
+    debug('on close')
     instance._server.close(done)
   })
 }
@@ -48,17 +53,22 @@ function create (original) {
   pump(stream, original, stream)
   stream.on('request', handle.bind(this))
 
+  /* istanbul ignore next */
   stream.on('error', err => {
+    debug('tentacoli error', err)
     this.close()
     this.emit('error', err)
   })
 }
 
 function handle (request, reply) {
+  debug('incoming request', request)
   var fn = this._functions[request.procedure]
   if (fn) {
+    debug('found procedure')
     var result = fn.call(this, request, reply)
   } else {
+    debug('proceudre not found')
     reply(new Error('404'), null)
     return
   }
@@ -78,6 +88,8 @@ Server.prototype.register = function (procedure, fn) {
   assert(typeof procedure === 'string', 'key must be a string')
   assert(typeof fn === 'function', 'fn must be a function')
   assert(!this._functions[procedure], `You have already registered procedure '${procedure}'`)
+  debug('register new procedure:', procedure)
+
   this._functions[procedure] = fn
   return this
 }
@@ -85,7 +97,9 @@ Server.prototype.register = function (procedure, fn) {
 Server.prototype.listen = function (portOrPath, cb) {
   assert(typeof portOrPath === 'number' || typeof portOrPath === 'string', 'portOrPath should be a number or a string')
   cb = cb || noop
+
   this.ready(err => {
+    debug(`Run the ${typeof portOrPath === 'number' ? 'tcp' : 'ipc'} server`)
     /* istanbul ignore if */
     if (err) return cb(err)
     this._server.listen(portOrPath, cb)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/delvedor/rinvoke#readme",
   "dependencies": {
     "avvio": "^2.0.3",
+    "debug": "^2.6.8",
     "minimist": "^1.2.0",
     "pump": "^1.0.2",
     "tentacoli": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
   "homepage": "https://github.com/delvedor/rinvoke#readme",
   "dependencies": {
     "avvio": "^2.0.3",
-    "bloomrun": "^3.0.4",
-    "hyperid": "^1.2.0",
     "minimist": "^1.2.0",
-    "tinysonic": "^1.2.0",
-    "zmq": "^2.15.3"
+    "pump": "^1.0.2",
+    "tentacoli": "^0.6.1",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -6,27 +6,29 @@ const sleep = require('then-sleep')
 
 function asyncTest (test, port) {
   test('should support async await', t => {
-    t.plan(6)
-    const addr = 'tcp://127.0.0.1:' + port
+    t.plan(7)
     const server = Server()
 
-    server.register('cmd:concat', async (a, b) => {
-      t.equal(a, 'a')
-      t.equal(b, 'b')
+    server.register('concat', async req => {
+      t.equal(req.a, 'a')
+      t.equal(req.b, 'b')
       await sleep(200)
-      return a + b
+      return req.a + req.b
     })
 
-    server.run(addr, err => {
+    server.listen(port, err => {
       t.error(err)
 
-      const client = Client()
+      const client = Client({ port })
 
-      client.connect(addr)
-      client.invoke('cmd:concat', 'a', 'b', (err, res) => {
+      client.invoke({
+        procedure: 'concat',
+        a: 'a',
+        b: 'b'
+      }, (err, res) => {
         t.error(err)
         t.equal(res, 'ab')
-        client.close()
+        client.close(t.error)
         server.close(t.error)
       })
     })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -190,6 +190,71 @@ test('should register a function and reply to the request (promises - reject)', 
   })
 })
 
+test('client should set timeout and keep alive', t => {
+  t.plan(8)
+  const server = Server()
+
+  server.register('concat', (req, reply) => {
+    t.equal(req.a, 'a')
+    t.equal(req.b, 'b')
+    t.is(typeof reply, 'function')
+    reply(null, req.a + req.b)
+  })
+
+  server.listen(port, err => {
+    t.error(err)
+
+    const client = Client({ port })
+
+    client.timeout(500)
+    client.keepAlive(true)
+
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res, 'ab')
+      client.close(t.error)
+      server.close(t.error)
+    })
+  })
+})
+
+test('client should set timeout and keep alive / 2', t => {
+  t.plan(8)
+  const server = Server()
+
+  server.register('concat', (req, reply) => {
+    t.equal(req.a, 'a')
+    t.equal(req.b, 'b')
+    t.is(typeof reply, 'function')
+    reply(null, req.a + req.b)
+  })
+
+  server.listen(port, err => {
+    t.error(err)
+
+    const client = Client({ port })
+
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res, 'ab')
+
+      client.timeout(500)
+      client.keepAlive(true)
+
+      client.close(t.error)
+      server.close(t.error)
+    })
+  })
+})
+
 test('async await support', t => {
   if (Number(process.versions.node[0]) >= 8) {
     require('./async-await')(t.test, port)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,138 +17,174 @@ beforeEach(done => {
   })
 })
 
-test('server methods', t => {
-  t.plan(10)
-  const server = Server()
-  t.ok(server.run)
-  t.ok(server.register)
-  t.ok(server.close)
-  t.ok(server.parser)
-  t.ok(server.serializer)
-  t.ok(server.errorSerializer)
-  t.ok(server.use)
-  t.ok(server.ready)
-  t.ok(server.after)
-  server.close(t.error)
-})
-
-test('client methods', t => {
-  t.plan(7)
-  const client = Client()
-  t.ok(client.connect)
-  t.ok(client.invoke)
-  t.ok(client.close)
-  t.ok(client.disconnect)
-  t.ok(client.parser)
-  t.ok(client.errorParser)
-  t.ok(client.serializer)
-  client.close()
-})
-
 test('should register a function and reply to the request', t => {
-  t.plan(7)
-  const addr = 'tcp://127.0.0.1:' + port
+  t.plan(8)
   const server = Server()
 
-  server.register('cmd:concat', (a, b, reply) => {
-    t.equal(a, 'a')
-    t.equal(b, 'b')
+  server.register('concat', (req, reply) => {
+    t.equal(req.a, 'a')
+    t.equal(req.b, 'b')
     t.is(typeof reply, 'function')
-    reply(null, a + b)
+    reply(null, req.a + req.b)
   })
 
-  server.run(addr, err => {
+  server.listen(port, err => {
     t.error(err)
 
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect(addr)
-    client.invoke('cmd:concat', 'a', 'b', (err, res) => {
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
       t.error(err)
       t.equal(res, 'ab')
-      client.close()
+      client.close(t.error)
       server.close(t.error)
     })
   })
 })
 
-test('should register a function and reply to the request - error', t => {
-  t.plan(4)
-  const addr = 'tcp://127.0.0.1:' + port
+test('should register a function and reply to the request (multiple)', t => {
+  t.plan(13)
   const server = Server()
 
-  server.errorSerializer(e => e.message)
+  server.register('concat', (req, reply) => {
+    t.equal(req.a, 'a')
+    t.equal(req.b, 'b')
+    t.is(typeof reply, 'function')
+    reply(null, req.a + req.b)
+  })
 
-  server.register('cmd:concat', (a, b, reply) => {
+  server.listen(port, err => {
+    t.error(err)
+
+    const client = Client({ port })
+
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res, 'ab')
+
+      client.invoke({
+        procedure: 'concat',
+        a: 'a',
+        b: 'b'
+      }, (err, res) => {
+        t.error(err)
+        t.equal(res, 'ab')
+        client.close(t.error)
+        server.close(t.error)
+      })
+    })
+  })
+})
+
+test('should register a function and reply to the request - error', t => {
+  t.plan(5)
+  const server = Server()
+
+  server.register('concat', (req, reply) => {
     reply(new Error('some error'), null)
   })
 
-  server.run(addr, err => {
+  server.listen(port, err => {
     t.error(err)
 
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect(addr)
-    client.invoke('cmd:concat', 'a', 'b', (err, res) => {
-      t.equal(err, 'some error')
-      t.equal(res, 'null')
-      client.close()
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.equal(err.message, 'some error')
+      t.equal(res, null)
+      client.close(t.error)
+      server.close(t.error)
+    })
+  })
+})
+
+test('function not found', t => {
+  t.plan(5)
+  const server = Server()
+
+  server.listen(port, err => {
+    t.error(err)
+
+    const client = Client({ port })
+
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.equal(err.message, '404')
+      t.equal(res, null)
+      client.close(t.error)
       server.close(t.error)
     })
   })
 })
 
 test('should register a function and reply to the request (promises - resolve)', t => {
-  t.plan(4)
-  const addr = 'tcp://127.0.0.1:' + port
+  t.plan(5)
   const server = Server()
 
-  server.register('cmd:concat', (a, b, reply) => {
+  server.register('concat', (req, reply) => {
     const p = new Promise((resolve, reject) => {
-      resolve(a + b)
+      resolve(req.a + req.b)
     })
     return p
   })
 
-  server.run(addr, err => {
+  server.listen(port, err => {
     t.error(err)
 
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect(addr)
-    client.invoke('cmd:concat', 'a', 'b', (err, res) => {
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
       t.error(err)
       t.equal(res, 'ab')
-      client.close()
+      client.close(t.error)
       server.close(t.error)
     })
   })
 })
 
 test('should register a function and reply to the request (promises - reject)', t => {
-  t.plan(4)
-  const addr = 'tcp://127.0.0.1:' + port
+  t.plan(5)
   const server = Server()
 
-  server.errorSerializer(e => e.message)
-
-  server.register('cmd:concat', (a, b, reply) => {
+  server.register('concat', (req, reply) => {
     const p = new Promise((resolve, reject) => {
       reject(new Error('some error'))
     })
     return p
   })
 
-  server.run(addr, err => {
+  server.listen(port, err => {
     t.error(err)
 
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect(addr)
-    client.invoke('cmd:concat', 'a', 'b', (err, res) => {
-      t.equal(err, 'some error')
-      t.equal(res, 'null')
-      client.close()
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.equal(err.message, 'some error')
+      t.equal(res, null)
+      client.close(t.error)
       server.close(t.error)
     })
   })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -18,42 +18,38 @@ beforeEach(done => {
 })
 
 test('cli single function', t => {
-  t.plan(3)
+  t.plan(4)
 
   cli.start({
-    protocol: 'tcp',
-    address: '127.0.0.1',
+    host: '127.0.0.1',
     port: port,
     _: ['./examples/cli-single-function.js']
   }, server => {
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect('tcp://127.0.0.1:' + port)
-    client.invoke('hello', (err, res) => {
+    client.invoke({ procedure: 'hello' }, (err, res) => {
       t.error(err)
       t.equal(res, 'hello!')
-      client.close()
+      client.close(t.error)
       server.close(t.error)
     })
   })
 })
 
 test('cli extended', t => {
-  t.plan(3)
+  t.plan(4)
 
   cli.start({
-    protocol: 'tcp',
-    address: '127.0.0.1',
+    host: '127.0.0.1',
     port: port,
     _: ['./examples/cli-extended.js']
   }, server => {
-    const client = Client()
+    const client = Client({ port })
 
-    client.connect('tcp://127.0.0.1:' + port)
-    client.invoke('hello', (err, res) => {
+    client.invoke({ procedure: 'hello' }, (err, res) => {
       t.error(err)
-      t.equal(res, JSON.stringify({ hello: 'world' }))
-      client.close()
+      t.deepEqual(res, { hello: 'world' })
+      client.close(t.error)
       server.close(t.error)
     })
   })

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,48 +1,11 @@
 'use strict'
 
 const t = require('tap')
-const beforeEach = t.beforeEach
 const test = t.test
 const Server = require('../lib/server')
-const Client = require('../lib/client')
-const getPort = require('./get-port')
-
-var port = 0
-
-beforeEach(done => {
-  getPort((err, p) => {
-    if (err) throw err
-    port = p
-    done()
-  })
-})
-
-test('reply should send errors', t => {
-  t.plan(4)
-  const addr = 'tcp://127.0.0.1:' + port
-  const server = Server()
-
-  server.register('cmd:concat', function (a, b, reply) {
-    reply(new Error('argh!'), null)
-  })
-
-  server.run(addr, err => {
-    t.error(err)
-
-    const client = Client()
-
-    client.connect(addr)
-    client.invoke('cmd:concat', 'a', 'b', (err, res) => {
-      t.ok(err)
-      t.equal(res, 'null')
-      client.close()
-      server.close(t.error)
-    })
-  })
-})
 
 test('server assertions', t => {
-  t.plan(7)
+  t.plan(3)
   const server = Server()
 
   try {
@@ -60,67 +23,9 @@ test('server assertions', t => {
   }
 
   try {
-    server.run(null)
+    server.listen(null)
     t.fail()
   } catch (e) {
-    t.is(e.message, 'address should be a string')
+    t.is(e.message, 'port should be a number')
   }
-
-  try {
-    server.parser(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'parser must be a function')
-  }
-
-  try {
-    server.serializer(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'serializer must be a function')
-  }
-
-  try {
-    server.errorSerializer(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'serializer must be a function')
-  }
-
-  server.close(t.error)
-})
-
-test('client assertions', t => {
-  t.plan(4)
-  const client = Client()
-
-  try {
-    client.connect(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'address should be a string')
-  }
-
-  try {
-    client.parser(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'parser must be a function')
-  }
-
-  try {
-    client.serializer(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'serializer must be a function')
-  }
-
-  try {
-    client.errorParser(null)
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'parser must be a function')
-  }
-
-  client.close()
 })

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -26,6 +26,6 @@ test('server assertions', t => {
     server.listen(null)
     t.fail()
   } catch (e) {
-    t.is(e.message, 'port should be a number')
+    t.is(e.message, 'portOrPath should be a number or a string')
   }
 })

--- a/test/ipc.test.js
+++ b/test/ipc.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const fs = require('fs')
+const t = require('tap')
+const beforeEach = t.beforeEach
+const test = t.test
+const Server = require('../lib/server')
+const Client = require('../lib/client')
+
+const socket = '/tmp/ipc-test.sock'
+
+beforeEach(done => {
+  fs.unlink(socket, () => done())
+})
+
+test('Should communicate via ipc', t => {
+  t.plan(8)
+  const server = Server()
+
+  server.register('concat', (req, reply) => {
+    t.equal(req.a, 'a')
+    t.equal(req.b, 'b')
+    t.is(typeof reply, 'function')
+    reply(null, req.a + req.b)
+  })
+
+  server.listen(socket, err => {
+    t.error(err)
+
+    const client = Client({ path: socket })
+
+    client.invoke({
+      procedure: 'concat',
+      a: 'a',
+      b: 'b'
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res, 'ab')
+      client.close(t.error)
+      server.close(t.error)
+    })
+  })
+})

--- a/test/reconnect.test.js
+++ b/test/reconnect.test.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const t = require('tap')
+const beforeEach = t.beforeEach
+const test = t.test
+const Server = require('../lib/server')
+const Client = require('../lib/client')
+const getPort = require('./get-port')
+
+var port = 0
+
+beforeEach(done => {
+  getPort((err, p) => {
+    if (err) throw err
+    port = p
+    done()
+  })
+})
+
+test('the client should try to reconnect before emit an error', t => {
+  t.plan(7)
+
+  setTimeout(() => {
+    const server = Server()
+    server.register('concat', (req, reply) => {
+      t.equal(req.a, 'a')
+      t.equal(req.b, 'b')
+      t.is(typeof reply, 'function')
+      reply(null, req.a + req.b)
+    })
+
+    server.listen(port, t.error)
+    server.on('connection', server.close)
+  }, 1000)
+
+  const client = Client({
+    port: port,
+    reconnect: {
+      timeout: 1500
+    }
+  })
+
+  client.on('error', () => {
+    t.fail('should not error')
+  })
+
+  client.invoke({
+    procedure: 'concat',
+    a: 'a',
+    b: 'b'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res, 'ab')
+    client.close(t.error)
+  })
+})
+
+test('client reconnect fail', t => {
+  t.plan(1)
+
+  const client = Client({
+    port: port,
+    reconnect: {
+      timeout: 100
+    }
+  })
+
+  client.on('error', () => {
+    t.pass('should error')
+  })
+})
+
+test('client without reconnect', t => {
+  t.plan(1)
+
+  const client = Client({
+    port: port
+  })
+
+  client.on('error', () => {
+    t.pass('should error')
+  })
+})


### PR DESCRIPTION
ZMQ is awesome until everything is good, handling stuff like timeouts is a hell.
With this pr `zmq` has been completely removed, from now onwards I'll use [`net`](https://nodejs.org/api/net.html) sockets.

The api has changed a lot, since internally I'm using [`tentacoli`](https://github.com/mcollina/tentacoli) as request multiplexer.